### PR TITLE
Hide the labels Address, Tel and Email if they are not defined in the config file

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -6,10 +6,12 @@
           <a href="{{.Site.BaseURL}}"><img src="{{.Site.Params.logo | absURL }}" alt="{{.Site.Title}}" class="img-fluid"></a>
         </div>
         <div class="col-md-3 col-sm-6 mb-4 mb-md-0">
+          {{ if .Site.Params.address }}
           <h6>Address</h6>
           <ul class="list-unstyled">
             <li class="font-secondary text-dark">{{.Site.Params.address | markdownify }}</li>
           </ul>
+          {{ end }}
         </div>
         <div class="col-md-3 col-sm-6 mb-4 mb-md-0">
           {{ if or  .Site.Params.mobile  .Site.Params.email }}         

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -12,11 +12,17 @@
           </ul>
         </div>
         <div class="col-md-3 col-sm-6 mb-4 mb-md-0">
+          {{ if or  .Site.Params.mobile  .Site.Params.email }}         
           <h6>Contact Info</h6>
           <ul class="list-unstyled">
+            {{ if .Site.Params.mobile }}
             <li class="font-secondary text-dark">Tel : {{ .Site.Params.mobile | markdownify }}</li>
+            {{ end }}
+            {{ if .Site.Params.email }}           
             <li class="font-secondary text-dark">Email : {{ .Site.Params.email | markdownify }}</li>
+            {{ end }}
           </ul>
+          {{ end }}
         </div>
         <div class="col-md-3 col-sm-6 mb-4 mb-md-0">
           <h6>Follow</h6>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -17,17 +17,12 @@
           {{ if or  .Site.Params.mobile  .Site.Params.email }}         
           <h6>Contact Info</h6>
           <ul class="list-unstyled">
-<<<<<<< HEAD
             {{ if .Site.Params.mobile }}
-            <li class="font-secondary text-dark">Tel : {{ .Site.Params.mobile | markdownify }}</li>
+            <li class="font-secondary text-dark">Tel : {{ .site.Params.mobile | markdownify }}</li>
             {{ end }}
             {{ if .Site.Params.email }}           
-            <li class="font-secondary text-dark">Email : {{ .Site.Params.email | markdownify }}</li>
+            <li class="font-secondary text-dark">Email : {{ .site.Params.email | markdownify }}</li>
             {{ end }}
-=======
-            <li class="font-secondary text-dark">Tel : {{ site.Params.mobile | markdownify }}</li>
-            <li class="font-secondary text-dark">Email : {{ site.Params.email | markdownify }}</li>
->>>>>>> df24e83ce3d2ac97f64500bb77538447815d9cc7
           </ul>
           {{ end }}
         </div>


### PR DESCRIPTION
If you want to omit the Address, Tel and Email, the tags are still showing up in the footer.

Add if statements to hide the tags if the Address, Tel and Email are not configure in config file.