### PR TITLE
Use the .Title value for the <title> tag when available

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,6 +1,6 @@
 <head>
   <meta charset="utf-8">
-  <title>{{ site.Title }}</title>
+  <title>{{ with .Title }}{{ . }}{{ else }}{{ with site.Title }}{{ . }}{{ end }}{{ end }}</title>
 
   {{ "<!-- mobile responsive meta -->" | safeHTML }}
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">


### PR DESCRIPTION
This patch uses the `title` value found in the `.md` file
for the <title> tag when it is available. The fall back value
is still `site.Title`.